### PR TITLE
Pin flask-sqlalchemy and sqlalchemy to older versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 flask>=1.0
 flask-dance[sqla]>=1.4.0
-flask-sqlalchemy
+flask-sqlalchemy<3
 flask-login>=0.5.0
 blinker
+sqlalchemy<2
 
 # only if you're using a Procfile, such as on Heroku
 gunicorn


### PR DESCRIPTION
Tests started failing with API changes to flask-sqlalchemy/sqlalchemy in their latest major versions (released mid-2022).  This fixes the tests failing due to those issues, though one failing test (for other reasons) still remains.